### PR TITLE
Inital parallel compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ virtualenv:
 before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo apt-get update -qq ; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo apt-get install -qq python-scipy python-nose python-pip ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo pip install scikit-learn ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo pip install scikit-learn joblib ; fi
 install:
     - python setup.py build_ext --inplace
     - if [ "${COVERAGE}" == "--with-coverage" ]; then sudo pip install coverage; fi


### PR DESCRIPTION
Embarrassingly parallel compilation of trees. What this PR does:

- parallel compilation of each tree, plus linking trees in ensemble 
- writing to files instead of lists; RAM usage is limited to minimum
- don't leave any temp file left after execution

TODO:

- [x] expose n_jobs to the user
- [x] delete temporary files after compilation (if delete=True, they don't survive joblib.Parallel)
- [x] rebase into one commit

Benchmarks:
For my large models i went down on compiling RF from 18 hours to ~30 min on 32 CPUs. RAM usage is trimmed to minimum, almost not existent (especially aside such large model).