### PR TITLE
Make numpy array contiguous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - conda update --yes conda
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION
+    - conda create --name test_env --yes python=$TRAVIS_PYTHON_VERSION
+    - source activate test_env
     - conda install --yes scipy nose scikit-learn joblib six
 install:
     - python setup.py build_ext --inplace

--- a/compiledtrees/compiled.py
+++ b/compiledtrees/compiled.py
@@ -130,6 +130,8 @@ class CompiledRegressionPredictor(RegressorMixin):
         y: array of shape = [n_samples]
             The predicted values.
         """
+        if not X.flags['C_CONTIGUOUS']:
+            X = np.ascontiguousarray(X)
         if X.dtype != DTYPE:
             X = X.astype(DTYPE)
         if X.ndim != 2:

--- a/compiledtrees/tests/test_compiled.py
+++ b/compiledtrees/tests/test_compiled.py
@@ -119,6 +119,29 @@ class TestCompiledTrees(unittest.TestCase):
                           np.resize(X, (1, num_features, num_features)))
             assert_allclose(compiled.score(X, y), clf.score(X, y))
 
+    def test_float32_and_float_64_predictions_are_equal(self):
+        num_features = 100
+        num_examples = 100
+
+        X = np.random.normal(size=(num_features, num_examples))
+        X_32 = X.astype(np.float32)
+        X_64 = X.astype(np.float64)
+        y = np.random.normal(size=num_examples)
+
+        # fit on X_32
+        rf = ensemble.RandomForestRegressor()
+        rf.fit(X_32, y)
+        rf = CompiledRegressionPredictor(rf)
+
+        assert_array_equal(rf.predict(X_32), rf.predict(X_64))
+
+        # fit on X_64
+        rf = ensemble.RandomForestRegressor()
+        rf.fit(X_64, y)
+        rf = CompiledRegressionPredictor(rf)
+
+        assert_array_equal(rf.predict(X_32), rf.predict(X_64))
+
     def test_predictions_with_non_contiguous_input(self):
         num_features = 100
         num_examples = 100
@@ -140,7 +163,4 @@ class TestCompiledTrees(unittest.TestCase):
 
         X_contiguous = np.ascontiguousarray(X_non_contiguous)
         self.assertTrue(X_contiguous.flags['C_CONTIGUOUS'])
-        assert_array_equal(rf_compiled.predict(X_non_contiguous), rf_compiled.predict(X_contiguous))
-
-        X_contiguous = X_contiguous.astype(np.float64)
         assert_array_equal(rf_compiled.predict(X_non_contiguous), rf_compiled.predict(X_contiguous))


### PR DESCRIPTION
I'm using sklearn with pandas, as many people do. The numpy matrix in the pandas dataframe isn't contiguous; this pull request makes it so, so it will work with the compiled predictor.

I think the best long term solution for prediction data issues like this is to use the existing sklearn input validators (like https://github.com/scikit-learn/scikit-learn/blob/412996f09b6756752dfd3736c306d46fca8f1aa1/sklearn/utils/validation.py#L272), but that's beyond me right now. This is a quick fix that will hopefully make using compiled trees easier for many people.