### PR TITLE
Switch to msys2 GCC compiler for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
     - "2.7"
     - "3.5"
+    - "3.6"
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
@@ -11,9 +12,9 @@ before_install:
     - conda create --name test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate test_env
     - conda install --yes scipy nose scikit-learn joblib six
+    - pip install coverage codecov
 install:
     - python setup.py build_ext --inplace
-    - pip install coverage codecov
 script:
     - make test-coverage
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,13 @@ Or to get the latest development version:
 
 sklearn-compiledtrees has been tested to work on OS X, Linux and Windows.
 
-Installing on Windows requires MinGW and dlfcn-win32_,
+Installing on Windows requires GCC compiler and dlfcn-win32_,
 setting `CXX` environment variable (`set "CXX=gcc -pthread"` for CMD),
-and manual installation from source direcory.
+and manual installation from source directory. Using msys2 distribution in conda
+is strongly recommended.
 
 .. code:: bash
-
+    conda install -c msys2 m2w64-toolchain m2w64-dlfcn pywin32
     python setup.py build_ext --compiler=mingw32 -llibdl
     python setup.py install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,21 @@ environment:
     #  PYTHON_ARCH: "32"
     #  CONDA_PY: "35"
 
-    # - PYTHON: "C:\\Python35_64"
-    #   PYTHON_VERSION: "3.5"
-    #   PYTHON_ARCH: "64"
-    #   CONDA_PY: "35"
+    - PYTHON: "C:\\Python35_64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "35"
+
+    - PYTHON: "C:\\Python36_64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "36"
 
 install:
     # https://www.appveyor.com/docs/installed-software#python
     - if "%PYTHON_VERSION%" == "3.4" set "BASE_PYTHON_VERSION=3"
     - if "%PYTHON_VERSION%" == "3.5" set "BASE_PYTHON_VERSION=35"
+    - if "%PYTHON_VERSION%" == "3.6" set "BASE_PYTHON_VERSION=36"
     - if "%PYTHON_ARCH%" == "64" set "ARCH_LABEL=-x64"
     # These are already installed on appveyor.  Update them.
     - set "CONDA_ROOT=C:\Miniconda%BASE_PYTHON_VERSION%%ARCH_LABEL%"
@@ -48,7 +54,7 @@ install:
     - conda create --yes --name test_env python=%PYTHON_VERSION%
     - activate test_env
     - conda install -q  six numpy scikit-learn joblib nose
-    - conda install -q -c mwojcikowski mingwpy dlfcn
+    - conda install -q -c msys2 m2w64-toolchain m2w64-dlfcn pywin32
     - pip install coverage codecov
     - set "CXX=gcc -pthread"
     - python setup.py build_ext --inplace --compiler=mingw32 -llibdl

--- a/compiledtrees/code_gen.py
+++ b/compiledtrees/code_gen.py
@@ -26,7 +26,10 @@ ALWAYS_INLINE = "__attribute__((__always_inline__))"
 
 class CodeGenerator(object):
     def __init__(self):
-        self._file = tempfile.NamedTemporaryFile(prefix='compiledtrees_', suffix='.cpp', delete=delete_files)
+        self._file = tempfile.NamedTemporaryFile(mode='w+b',
+                                                 prefix='compiledtrees_',
+                                                 suffix='.cpp',
+                                                 delete=delete_files)
         self._indent = 0
 
     @property
@@ -93,6 +96,7 @@ def code_gen_tree(tree, evaluate_fn=EVALUATE_FN_NAME, gen=None):
             recur(0)
     return gen.file
 
+
 def _gen_tree(i, tree):
     """
     Generates cpp code for i'th tree.
@@ -101,6 +105,7 @@ def _gen_tree(i, tree):
     name = "{name}_{index}".format(name=EVALUATE_FN_NAME, index=i)
     gen_tree = CodeGenerator()
     return code_gen_tree(tree, name, gen_tree)
+
 
 def code_gen_ensemble(trees, individual_learner_weight, initial_value,
                       gen=None, n_jobs=1):
@@ -155,7 +160,7 @@ def code_gen_ensemble(trees, individual_learner_weight, initial_value,
     if gen is None:
         gen = CodeGenerator()
 
-    tree_files =[_gen_tree(i, tree) for i, tree in enumerate(trees)]
+    tree_files = [_gen_tree(i, tree) for i, tree in enumerate(trees)]
 
     with gen.bracketed('extern "C" {', "}"):
         # add dummy definitions if you will compile in parallel
@@ -175,19 +180,26 @@ def code_gen_ensemble(trees, individual_learner_weight, initial_value,
             gen.write("return result;")
     return tree_files + [gen.file]
 
+
 def _compile(cpp_f):
     if CXX_COMPILER is None:
-        raise Exception("CXX compiler was not found. You should set CXX environmental variable")
-    o_f = tempfile.NamedTemporaryFile(prefix='compiledtrees_', suffix='.o', delete=delete_files)
+        raise Exception("CXX compiler was not found. You should set CXX "
+                        "environmental variable")
+    o_f = tempfile.NamedTemporaryFile(mode='w+b',
+                                      prefix='compiledtrees_',
+                                      suffix='.o',
+                                      delete=delete_files)
     if platform.system() == 'Windows':
         o_f.close()
     _call([CXX_COMPILER, cpp_f, "-c", "-fPIC", "-o", o_f.name, "-O3", "-pipe"])
     return o_f
 
+
 def _call(args):
     DEVNULL = open(os.devnull, 'w')
     subprocess.check_call(" ".join(args),
                           shell=True, stdout=DEVNULL, stderr=DEVNULL)
+
 
 def compile_code_to_object(files, n_jobs=1):
     # if ther is a single file then create single element list
@@ -200,9 +212,13 @@ def compile_code_to_object(files, n_jobs=1):
         for f in files:
             f.close()
 
-    o_files = Parallel(n_jobs=n_jobs, backend='threading')(delayed(_compile)(f.name) for f in files)
+    o_files = (Parallel(n_jobs=n_jobs, backend='threading')
+               (delayed(_compile)(f.name) for f in files))
 
-    so_f = tempfile.NamedTemporaryFile(prefix='compiledtrees_', suffix='.so', delete=delete_files)
+    so_f = tempfile.NamedTemporaryFile(mode='w+b',
+                                       prefix='compiledtrees_',
+                                       suffix='.so',
+                                       delete=delete_files)
     # Close files on Windows to avoid permission errors
     if platform.system() == 'Windows':
         so_f.close()
@@ -210,11 +226,15 @@ def compile_code_to_object(files, n_jobs=1):
     # link trees
     if platform.system() == 'Windows':
         # a hack to overcome large RFs on windows and CMD 9182 chaacters limit
-        list_ofiles = tempfile.NamedTemporaryFile(prefix='list_ofiles_', delete=delete_files)
+        list_ofiles = tempfile.NamedTemporaryFile(mode='w+b',
+                                                  prefix='list_ofiles_',
+                                                  delete=delete_files)
         for f in o_files:
-            list_ofiles.write(f.name.replace('\\', '\\\\') + "\r")
+            list_ofiles.write((f.name.replace('\\', '\\\\') +
+                               "\r").encode('latin1'))
         list_ofiles.close()
-        _call([CXX_COMPILER, "-shared", "@%s" % list_ofiles.name, "-fPIC", "-flto", "-o", so_f.name, "-O3", "-pipe"])
+        _call([CXX_COMPILER, "-shared", "@%s" % list_ofiles.name, "-fPIC",
+               "-flto", "-o", so_f.name, "-O3", "-pipe"])
 
         # cleanup files
         for f in o_files:
@@ -224,7 +244,7 @@ def compile_code_to_object(files, n_jobs=1):
         os.unlink(list_ofiles.name)
     else:
         _call([CXX_COMPILER, "-shared"] +
-              [f.name for f in o_files]  +
+              [f.name for f in o_files] +
               ["-fPIC", "-flto", "-o", so_f.name, "-O3", "-pipe"])
 
     return so_f

--- a/compiledtrees/compiled.py
+++ b/compiledtrees/compiled.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import six
+
 from sklearn.base import RegressorMixin
 from sklearn.tree.tree import DecisionTreeRegressor, DTYPE, DOUBLE
 from sklearn.ensemble.gradient_boosting import GradientBoostingRegressor
@@ -18,6 +20,7 @@ if platform.system() == 'Windows':
     delete_files = False
 else:
     delete_files = True
+
 
 class CompiledRegressionPredictor(RegressorMixin):
     """Class to construct a compiled predictor from a previously trained
@@ -44,7 +47,12 @@ class CompiledRegressionPredictor(RegressorMixin):
 
     def __setstate__(self, state):
         import tempfile
-        self._so_f_object = tempfile.NamedTemporaryFile(mode='w+b', prefix='compiledtrees_', suffix='.so', delete=delete_files)
+        self._so_f_object = tempfile.NamedTemporaryFile(mode='w+b',
+                                                        prefix='compiledtrees_',
+                                                        suffix='.so',
+                                                        delete=delete_files)
+        if isinstance(state["so_f"], six.text_type):
+            state["so_f"] = state["so_f"].encode('latin1')
         self._so_f_object.write(state["so_f"])
         self._so_f_object.flush()
         self._so_f = self._so_f_object.name

--- a/compiledtrees/setup.py
+++ b/compiledtrees/setup.py
@@ -13,6 +13,7 @@ def configuration(parent_package="", top_path=None):
                          sources=["_compiled.c"],
                          include_dirs=[numpy.get_include()],
                          libraries=libraries,
+                         extra_link_args=["-Wl,--allow-multiple-definition"],
                          extra_compile_args=["-O3", "-Wno-unused-function"])
     config.add_subpackage("tests")
     return config


### PR DESCRIPTION
Use `msys2` in windows, as `pymingw` has been abandoned and never delivered support for Python 3.5+